### PR TITLE
fix: loosen dep pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,10 +21,10 @@ packages = [
     { include = "ruuvitag_ble", from = "src" },
 ]
 dependencies = [
-    "bluetooth-data-tools~=0.1",
-    "bluetooth-sensor-state-data~=1.6",
-    "home-assistant-bluetooth~=1.6",
-    "sensor-state-data~=2.9",
+    "bluetooth-data-tools>=0.1",
+    "bluetooth-sensor-state-data>=1.6",
+    "home-assistant-bluetooth>=1.6",
+    "sensor-state-data>=2.9",
 ]
 
 [project.urls]


### PR DESCRIPTION
unblocks https://github.com/home-assistant/core/pull/94138

bluetooth-data-tools got a major version bump (not breaking for this lib)