### PR TITLE
fix: fix license classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ authors = [
     { name = "Aarni Koskela", email = "akx@iki.fi" },
 ]
 requires-python = ">=3.9"
-license = "MIT"
 readme = "README.md"
 repository = "https://github.com/bluetooth-devices/ruuvitag-ble"
 documentation = "https://ruuvitag-ble.readthedocs.io"
@@ -16,6 +15,7 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Libraries",
+    "License :: OSI Approved :: MIT License",
 ]
 packages = [
     { include = "ruuvitag_ble", from = "src" },


### PR DESCRIPTION
Hey 👋🏻,

I am currently looking into licensing at Home Assistant, and I found that we could not detect the license of this library properly. According to pyproject.toml documentation about the `license` field:
> If you are using a standard, well-known license, it is not necessary to use this field. Instead, you should use one of the [classifiers](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#classifiers) starting with License ::. (As a general rule, it is a good idea to use a standard, well-known license, both to avoid confusion and because some organizations avoid software whose license is unapproved.)

If you could do a release after this PR, and maybe bump in Home Assistant, that would be awesome :)