### PR TITLE
fix: revert license classifier change (#10)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ authors = [
     { name = "Aarni Koskela", email = "akx@iki.fi" },
 ]
 requires-python = ">=3.9"
+license = "MIT"
 readme = "README.md"
 repository = "https://github.com/bluetooth-devices/ruuvitag-ble"
 documentation = "https://ruuvitag-ble.readthedocs.io"
@@ -14,7 +15,6 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Libraries",
-    "License :: OSI Approved :: MIT License",
 ]
 packages = [
     { include = "ruuvitag_ble", from = "src" },


### PR DESCRIPTION
This reverts commit 5eb16644030da3eb9898cc1a6286e20d0f7f9345.