### PR TITLE
Add support for Ruuv Data Format 3 (RAWv1)

### DIFF
--- a/src/ruuvitag_ble/df3_decoder.py
+++ b/src/ruuvitag_ble/df3_decoder.py
@@ -1,0 +1,55 @@
+"""
+Decoder for RuuviTag Data Format 3 data.
+
+Ruuvi Sensor Protocols: https://github.com/ruuvi/ruuvi-sensor-protocols/blob/master/dataformat_03.md
+"""
+
+from __future__ import annotations
+
+import math
+import struct
+
+
+class DataFormat3Decoder:
+    def __init__(self, raw_data: bytes) -> None:
+        if len(raw_data) < 14:
+            raise ValueError("Data must be at least 14 bytes long for data format 3")
+        self.data: tuple[int, ...] = struct.unpack(">BBbBHhhhH", raw_data)
+
+    @property
+    def humidity_percentage(self) -> float | None:
+        if self.data[1] > 200:
+            return None
+        return round(self.data[1] / 2, 2)
+
+    @property
+    def temperature_celsius(self) -> float | None:
+        return round(self.data[2] + self.data[3] / 100.0, 2)
+
+    @property
+    def pressure_hpa(self) -> float | None:
+        if self.data[3] == 0xFFFF:
+            return None
+
+        return round((self.data[4] + 50000) / 100, 2)
+
+    @property
+    def acceleration_vector_mg(self) -> tuple[int, int, int] | tuple[None, None, None]:
+        ax = self.data[5]
+        ay = self.data[6]
+        az = self.data[7]
+        if ax == -32768 or ay == -32768 or az == -32768:
+            return (None, None, None)
+
+        return (ax, ay, az)
+
+    @property
+    def acceleration_total_mg(self) -> float | None:
+        ax, ay, az = self.acceleration_vector_mg
+        if ax is None or ay is None or az is None:
+            return None
+        return math.sqrt(ax * ax + ay * ay + az * az)
+
+    @property
+    def battery_voltage_mv(self) -> int | None:
+        return self.data[8]

--- a/src/ruuvitag_ble/parser.py
+++ b/src/ruuvitag_ble/parser.py
@@ -36,8 +36,7 @@ class RuuvitagBluetoothDeviceData(BluetoothData):
         decoder = decoder_classes.get(data_format, DataFormat5Decoder)(raw_data)
 
         # Compute short identifier from MAC address
-        # (preferring the MAC address the tag broadcasts).
-        identifier = short_address(decoder.mac or service_info.address)
+        identifier = short_address(service_info.address)
         self.set_device_type("RuuviTag")
         self.set_device_manufacturer("Ruuvi Innovations Ltd.")
         self.set_device_name(f"RuuviTag {identifier}")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,12 +3,10 @@ from sensor_state_data import DeviceClass, DeviceKey
 
 from ruuvitag_ble import RuuvitagBluetoothDeviceData
 
-OUTDOOR_SENSOR_DATA = (
+V5_SENSOR_DATA = (
     b"\x05\x05\xa0`\xa0\xc8\x9a\xfd4\x02\x8c\xff\x00cvriv\xde\xad{?\xef\xaf"
 )
-INDOOR_SENSOR_DATA = (
-    b"\x05\x0e\xa4M~\xc8\x18\xfc\xbc\xfd\xf0\xff\xb4+\xf6\x00\x10<\xd97\x0f\xf7\xaa\x48"
-)
+V3_SENSOR_DATA = b"\x03\xb2\x0c\x1f\xca \x00z\x00&\x03\xd0\x08\x8f"
 
 KEY_TEMPERATURE = DeviceKey(key=DeviceClass.TEMPERATURE, device_id=None)
 KEY_HUMIDITY = DeviceKey(key=DeviceClass.HUMIDITY, device_id=None)
@@ -29,9 +27,9 @@ def bytes_to_service_info(payload: bytes) -> BluetoothServiceInfo:
     )
 
 
-def test_parsing_outdoor():
+def test_parsing_v5():
     device = RuuvitagBluetoothDeviceData()
-    advertisement = bytes_to_service_info(OUTDOOR_SENSOR_DATA)
+    advertisement = bytes_to_service_info(V5_SENSOR_DATA)
     assert device.supported(advertisement)
     up = device.update(advertisement)
     expected_name = "RuuviTag EFAF"
@@ -41,3 +39,16 @@ def test_parsing_outdoor():
     assert up.entity_values[KEY_PRESSURE].native_value == 1013.54  # hPa
     assert up.entity_values[KEY_VOLTAGE].native_value == 2395  # mV
     assert up.entity_values[KEY_MOVEMENT].native_value == 114  # count
+
+
+def test_parsing_v3():
+    device = RuuvitagBluetoothDeviceData()
+    advertisement = bytes_to_service_info(V3_SENSOR_DATA)
+    assert device.supported(advertisement)
+    up = device.update(advertisement)
+    expected_name = "RuuviTag EFAF"
+    assert up.devices[None].name == expected_name  # Parsed from advertisement
+    assert up.entity_values[KEY_TEMPERATURE].native_value == 7.2  # Celsius
+    assert up.entity_values[KEY_HUMIDITY].native_value == 61.84  # %
+    assert up.entity_values[KEY_PRESSURE].native_value == 1013.54  # hPa
+    assert up.entity_values[KEY_VOLTAGE].native_value == 2395  # mV

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -18,7 +18,7 @@ KEY_MOVEMENT = DeviceKey(key="movement_counter", device_id=None)
 def bytes_to_service_info(payload: bytes) -> BluetoothServiceInfo:
     return BluetoothServiceInfo(
         name="Test",
-        address="00:00:00:00:00:00",
+        address="AB:CD:EF:BA:DC:FE",
         rssi=-60,
         manufacturer_data={1177: payload},
         service_data={},
@@ -32,7 +32,7 @@ def test_parsing_v5():
     advertisement = bytes_to_service_info(V5_SENSOR_DATA)
     assert device.supported(advertisement)
     up = device.update(advertisement)
-    expected_name = "RuuviTag EFAF"
+    expected_name = "RuuviTag DCFE"
     assert up.devices[None].name == expected_name  # Parsed from advertisement
     assert up.entity_values[KEY_TEMPERATURE].native_value == 7.2  # Celsius
     assert up.entity_values[KEY_HUMIDITY].native_value == 61.84  # %
@@ -46,9 +46,9 @@ def test_parsing_v3():
     advertisement = bytes_to_service_info(V3_SENSOR_DATA)
     assert device.supported(advertisement)
     up = device.update(advertisement)
-    expected_name = "RuuviTag EFAF"
+    expected_name = "RuuviTag DCFE"
     assert up.devices[None].name == expected_name  # Parsed from advertisement
-    assert up.entity_values[KEY_TEMPERATURE].native_value == 7.2  # Celsius
-    assert up.entity_values[KEY_HUMIDITY].native_value == 61.84  # %
-    assert up.entity_values[KEY_PRESSURE].native_value == 1013.54  # hPa
-    assert up.entity_values[KEY_VOLTAGE].native_value == 2395  # mV
+    assert up.entity_values[KEY_TEMPERATURE].native_value == 12.31  # Celsius
+    assert up.entity_values[KEY_HUMIDITY].native_value == 89.0  # %
+    assert up.entity_values[KEY_PRESSURE].native_value == 1017.44  # hPa
+    assert up.entity_values[KEY_VOLTAGE].native_value == 2191  # mV


### PR DESCRIPTION
Add support for the older Ruuvi Tag protocol [as described by Ruuvi](https://github.com/ruuvi/ruuvi-sensor-protocols).  Addresses #4.  Tested with fifteen Ruuvi Tags in a running Home Assistant instance, six of which use the Data Format 3 (RawV1) and nine of which use the Data Format 5 (RAWv2).