### PR TITLE
Add acceleration values and a few others, plus unit test improvements

### DIFF
--- a/src/ruuvitag_ble/df3_decoder.py
+++ b/src/ruuvitag_ble/df3_decoder.py
@@ -24,13 +24,12 @@ class DataFormat3Decoder:
 
     @property
     def temperature_celsius(self) -> float | None:
+        if self.data[2] == -128:
+            return None
         return round(self.data[2] + self.data[3] / 100.0, 2)
 
     @property
     def pressure_hpa(self) -> float | None:
-        if self.data[3] == 0xFFFF:
-            return None
-
         return round((self.data[4] + 50000) / 100, 2)
 
     @property

--- a/src/ruuvitag_ble/df3_decoder.py
+++ b/src/ruuvitag_ble/df3_decoder.py
@@ -44,6 +44,27 @@ class DataFormat3Decoder:
         return (ax, ay, az)
 
     @property
+    def acceleration_x_mss(self) -> float | None:
+        ax = self.data[5]
+        if ax == -32768:
+            return None
+        return round(ax / 1000.0 * 9.8, 2)
+
+    @property
+    def acceleration_y_mss(self) -> float | None:
+        ay = self.data[6]
+        if ay == -32768:
+            return None
+        return round(ay / 1000.0 * 9.8, 2)
+
+    @property
+    def acceleration_z_mss(self) -> float | None:
+        az = self.data[7]
+        if az == -32768:
+            return None
+        return round(az / 1000.0 * 9.8, 2)
+
+    @property
     def acceleration_total_mss(self) -> float | None:
         ax, ay, az = self.acceleration_vector_mg
         if ax is None or ay is None or az is None:

--- a/src/ruuvitag_ble/df3_decoder.py
+++ b/src/ruuvitag_ble/df3_decoder.py
@@ -44,11 +44,12 @@ class DataFormat3Decoder:
         return (ax, ay, az)
 
     @property
-    def acceleration_total_mg(self) -> float | None:
+    def acceleration_total_mss(self) -> float | None:
         ax, ay, az = self.acceleration_vector_mg
         if ax is None or ay is None or az is None:
             return None
-        return math.sqrt(ax * ax + ay * ay + az * az)
+        # Conversion from milliG to m/s^2
+        return math.sqrt(ax * ax + ay * ay + az * az) / 1000.0 * 9.8
 
     @property
     def battery_voltage_mv(self) -> int | None:

--- a/src/ruuvitag_ble/df3_decoder.py
+++ b/src/ruuvitag_ble/df3_decoder.py
@@ -70,7 +70,7 @@ class DataFormat3Decoder:
         if ax is None or ay is None or az is None:
             return None
         # Conversion from milliG to m/s^2
-        return math.sqrt(ax * ax + ay * ay + az * az) / 1000.0 * 9.8
+        return round(math.sqrt(ax * ax + ay * ay + az * az) / 1000.0 * 9.8, 2)
 
     @property
     def battery_voltage_mv(self) -> int | None:

--- a/src/ruuvitag_ble/df3_decoder.py
+++ b/src/ruuvitag_ble/df3_decoder.py
@@ -1,0 +1,55 @@
+"""
+Decoder for RuuviTag Data Format 3 data.
+
+Ruuvi Sensor Protocols: https://github.com/ruuvi/ruuvi-sensor-protocols/blob/master/dataformat_03.md
+"""
+
+from __future__ import annotations
+
+import math
+import struct
+
+
+class DataFormat3Decoder:
+    def __init__(self, raw_data: bytes) -> None:
+        if len(raw_data) < 14:
+            raise ValueError("Data must be at least 14 bytes long for data format 3")
+        self.data: tuple[int, ...] = struct.unpack(">BBbBHhhhH", raw_data)
+
+    @property
+    def humidity_percentage(self) -> float | None:
+        if self.data[1] > 200:
+            return None
+        return round(self.data[1] / 2, 2)
+
+    @property
+    def temperature_celsius(self) -> float | None:
+        return round(self.data[2] + self.data[3] / 100.0, 2)
+
+    @property
+    def pressure_hpa(self) -> float | None:
+        if self.data[3] == 0xFFFF:
+            return None
+
+        return round((self.data[4] + 50000) / 100, 2)
+
+    @property
+    def acceleration_vector_mg(self) -> tuple[int, int, int] | tuple[None, None, None]:
+        ax = self.data[5]
+        ay = self.data[6]
+        az = self.data[7]
+        if ax == -32768 or ay == -32768 or az == -32768:
+            return (None, None, None)
+
+        return (ax, ay, az)
+
+    @property
+    def acceleration_total_mg(self) -> float | None:
+        ax, ay, az = self.acceleration_vector_mg
+        if ax is None or ay is None or az is None:
+            return None
+        return math.sqrt(ax * ax + ay * ay + az * az)
+
+    @property
+    def battery_voltage_mv(self) -> int | None:
+        return self.data[8]

--- a/src/ruuvitag_ble/df3_decoder.py
+++ b/src/ruuvitag_ble/df3_decoder.py
@@ -74,7 +74,3 @@ class DataFormat3Decoder:
     @property
     def battery_voltage_mv(self) -> int | None:
         return self.data[8]
-
-    @property
-    def mac(self) -> str | None:
-        return None  # Not supported by this decoder

--- a/src/ruuvitag_ble/df5_decoder.py
+++ b/src/ruuvitag_ble/df5_decoder.py
@@ -46,11 +46,12 @@ class DataFormat5Decoder:
         return (ax, ay, az)
 
     @property
-    def acceleration_total_mg(self) -> float | None:
+    def acceleration_total_mss(self) -> float | None:
         ax, ay, az = self.acceleration_vector_mg
         if ax is None or ay is None or az is None:
             return None
-        return math.sqrt(ax * ax + ay * ay + az * az)
+        # Conversion to m/s^2
+        return math.sqrt(ax * ax + ay * ay + az * az) / 1000.0 * 9.8
 
     @property
     def battery_voltage_mv(self) -> int | None:

--- a/src/ruuvitag_ble/df5_decoder.py
+++ b/src/ruuvitag_ble/df5_decoder.py
@@ -32,7 +32,6 @@ class DataFormat5Decoder:
     def pressure_hpa(self) -> float | None:
         if self.data[3] == 0xFFFF:
             return None
-
         return round((self.data[3] + 50000) / 100, 2)
 
     @property

--- a/src/ruuvitag_ble/df5_decoder.py
+++ b/src/ruuvitag_ble/df5_decoder.py
@@ -46,6 +46,27 @@ class DataFormat5Decoder:
         return (ax, ay, az)
 
     @property
+    def acceleration_x_mss(self) -> float | None:
+        ax = self.data[4]
+        if ax == -32768:
+            return None
+        return round(ax / 1000.0 * 9.8, 2)
+
+    @property
+    def acceleration_y_mss(self) -> float | None:
+        ay = self.data[5]
+        if ay == -32768:
+            return None
+        return round(ay / 1000.0 * 9.8, 2)
+
+    @property
+    def acceleration_z_mss(self) -> float | None:
+        az = self.data[6]
+        if az == -32768:
+            return None
+        return round(az / 1000.0 * 9.8, 2)
+
+    @property
     def acceleration_total_mss(self) -> float | None:
         ax, ay, az = self.acceleration_vector_mg
         if ax is None or ay is None or az is None:

--- a/src/ruuvitag_ble/df5_decoder.py
+++ b/src/ruuvitag_ble/df5_decoder.py
@@ -72,7 +72,7 @@ class DataFormat5Decoder:
         if ax is None or ay is None or az is None:
             return None
         # Conversion to m/s^2
-        return math.sqrt(ax * ax + ay * ay + az * az) / 1000.0 * 9.8
+        return round(math.sqrt(ax * ax + ay * ay + az * az) / 1000.0 * 9.8, 2)
 
     @property
     def battery_voltage_mv(self) -> int | None:

--- a/src/ruuvitag_ble/df5_decoder.py
+++ b/src/ruuvitag_ble/df5_decoder.py
@@ -2,6 +2,7 @@
 Decoder for RuuviTag Data Format 5 data.
 
 Based on https://github.com/ttu/ruuvitag-sensor/blob/23e6555/ruuvitag_sensor/decoder.py (MIT Licensed)
+Ruuvi Sensor Protocols: https://github.com/ruuvi/ruuvi-sensor-protocols/blob/master/dataformat_05.md
 """
 
 from __future__ import annotations
@@ -41,7 +42,6 @@ class DataFormat5Decoder:
         az = self.data[6]
         if ax == -32768 or ay == -32768 or az == -32768:
             return (None, None, None)
-
         return (ax, ay, az)
 
     @property
@@ -76,17 +76,15 @@ class DataFormat5Decoder:
     @property
     def battery_voltage_mv(self) -> int | None:
         voltage = self.data[7] >> 5
-        if voltage == 0b11111111111:
+        if voltage > 2046:  # invalid per spec
             return None
-
         return voltage + 1600
 
     @property
     def tx_power_dbm(self) -> int | None:
         tx_power = self.data[7] & 0x001F
-        if tx_power == 0b11111:
+        if tx_power > 30:  # invalid per spec
             return None
-
         return -40 + (tx_power * 2)
 
     @property
@@ -96,7 +94,3 @@ class DataFormat5Decoder:
     @property
     def measurement_sequence_number(self) -> int:
         return self.data[9]
-
-    @property
-    def mac(self) -> str:
-        return ":".join(f"{x:02X}" for x in self.data[10:])

--- a/src/ruuvitag_ble/df5_decoder.py
+++ b/src/ruuvitag_ble/df5_decoder.py
@@ -76,14 +76,14 @@ class DataFormat5Decoder:
     @property
     def battery_voltage_mv(self) -> int | None:
         voltage = self.data[7] >> 5
-        if voltage > 2046:  # invalid per spec
+        if voltage == 2047:  # invalid per spec
             return None
         return voltage + 1600
 
     @property
     def tx_power_dbm(self) -> int | None:
         tx_power = self.data[7] & 0x001F
-        if tx_power > 30:  # invalid per spec
+        if tx_power == 31:  # invalid per spec
             return None
         return -40 + (tx_power * 2)
 

--- a/src/ruuvitag_ble/parser.py
+++ b/src/ruuvitag_ble/parser.py
@@ -72,6 +72,12 @@ class RuuvitagBluetoothDeviceData(BluetoothData):
             native_unit_of_measurement=Units.ELECTRIC_POTENTIAL_MILLIVOLT,
             native_value=decoder.battery_voltage_mv,
         )
+        self.update_sensor(
+            key=DeviceClass.ACCELERATION,
+            device_class=DeviceClass.ACCELERATION,
+            native_unit_of_measurement=Units.ACCELERATION_METERS_PER_SQUARE_SECOND,
+            native_value=decoder.acceleration_total_mss,
+        )
 
         if isinstance(decoder, DataFormat5Decoder):
             self.update_sensor(

--- a/src/ruuvitag_ble/parser.py
+++ b/src/ruuvitag_ble/parser.py
@@ -104,17 +104,17 @@ class RuuvitagBluetoothDeviceData(BluetoothData):
                 native_value=decoder.movement_counter,
             )
 
-        if hasattr(decoder, DeviceClass.SIGNAL_STRENGTH):
+        if hasattr(decoder, "tx_power_dbm"):
             self.update_sensor(
-                key=DeviceClass.SIGNAL_STRENGTH,
+                key="tx_power",
                 device_class=DeviceClass.SIGNAL_STRENGTH,
                 native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
                 native_value=decoder.tx_power_dbm,
             )
 
-        if hasattr(decoder, "sequence_number"):
+        if hasattr(decoder, "measurement_sequence_number"):
             self.update_sensor(
-                key="sequence_number",
+                key="measurement_sequence_number",
                 device_class=DeviceClass.COUNT,
                 native_unit_of_measurement=None,
                 native_value=decoder.measurement_sequence_number,

--- a/src/ruuvitag_ble/parser.py
+++ b/src/ruuvitag_ble/parser.py
@@ -73,7 +73,25 @@ class RuuvitagBluetoothDeviceData(BluetoothData):
             native_value=decoder.battery_voltage_mv,
         )
         self.update_sensor(
-            key=DeviceClass.ACCELERATION,
+            key="acceleration_x",
+            device_class=DeviceClass.ACCELERATION,
+            native_unit_of_measurement=Units.ACCELERATION_METERS_PER_SQUARE_SECOND,
+            native_value=decoder.acceleration_x_mss,
+        )
+        self.update_sensor(
+            key="acceleration_y",
+            device_class=DeviceClass.ACCELERATION,
+            native_unit_of_measurement=Units.ACCELERATION_METERS_PER_SQUARE_SECOND,
+            native_value=decoder.acceleration_y_mss,
+        )
+        self.update_sensor(
+            key="acceleration_z",
+            device_class=DeviceClass.ACCELERATION,
+            native_unit_of_measurement=Units.ACCELERATION_METERS_PER_SQUARE_SECOND,
+            native_value=decoder.acceleration_z_mss,
+        )
+        self.update_sensor(
+            key="acceleration_total",
             device_class=DeviceClass.ACCELERATION,
             native_unit_of_measurement=Units.ACCELERATION_METERS_PER_SQUARE_SECOND,
             native_value=decoder.acceleration_total_mss,

--- a/src/ruuvitag_ble/parser.py
+++ b/src/ruuvitag_ble/parser.py
@@ -27,7 +27,7 @@ class RuuvitagBluetoothDeviceData(BluetoothData):
         data_format = raw_data[0]
         if data_format not in (0x03, 0x05):
             _LOGGER.debug("Data format not supported: %s", raw_data)
-            return
+            return None
 
         decoder_classes: dict[
             int,
@@ -103,4 +103,16 @@ class RuuvitagBluetoothDeviceData(BluetoothData):
                 device_class=DeviceClass.COUNT,
                 native_unit_of_measurement=None,
                 native_value=decoder.movement_counter,
+            )
+            self.update_sensor(
+                key=DeviceClass.SIGNAL_STRENGTH,
+                device_class=DeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+                native_value=decoder.tx_power_dbm,
+            )
+            self.update_sensor(
+                key="sequence_number",
+                device_class=DeviceClass.COUNT,
+                native_unit_of_measurement=None,
+                native_value=decoder.measurement_sequence_number,
             )

--- a/src/ruuvitag_ble/parser.py
+++ b/src/ruuvitag_ble/parser.py
@@ -36,8 +36,7 @@ class RuuvitagBluetoothDeviceData(BluetoothData):
         decoder = decoder_classes.get(data_format, DataFormat5Decoder)(raw_data)
 
         # Compute short identifier from MAC address
-        # (preferring the MAC address the tag broadcasts).
-        identifier = short_address(decoder.mac or service_info.address)
+        identifier = short_address(service_info.address)
         self.set_device_type("RuuviTag")
         self.set_device_manufacturer("Ruuvi Innovations Ltd.")
         self.set_device_name(f"RuuviTag {identifier}")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -13,7 +13,7 @@ V5_SENSOR_DATA_SHORT = (
 )
 V3_SENSOR_DATA_SHORT = b"\x03\xb2\x0c\x1f\xca \x00z\x00&\x03\xd0\x08"
 V5_SENSOR_DATA_ERROR = b"\x05\x80\x00\xff\xff\xff\xff\x80\x00\x80\x00\x80\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
-V3_SENSOR_DATA_ERROR = b"\x03\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
+V3_SENSOR_DATA_ERROR = b"\x03\xff\x80\xff\xff\xff\x80\x00\x80\x00\x80\x00\xff\xff"
 
 KEY_TEMPERATURE = DeviceKey(key=DeviceClass.TEMPERATURE, device_id=None)
 KEY_HUMIDITY = DeviceKey(key=DeviceClass.HUMIDITY, device_id=None)
@@ -94,14 +94,13 @@ def test_parsing_v3():
 
 def test_error_v3():
     device = RuuvitagBluetoothDeviceData()
-    advertisement = bytes_to_service_info(V5_SENSOR_DATA_ERROR)
+    advertisement = bytes_to_service_info(V3_SENSOR_DATA_ERROR)
     assert device.supported(advertisement)
     up = device.update(advertisement)
     expected_name = "RuuviTag DCFE"
     assert up.devices[None].name == expected_name  # Parsed from advertisement
     assert up.entity_values[KEY_TEMPERATURE].native_value is None
     assert up.entity_values[KEY_HUMIDITY].native_value is None
-    assert up.entity_values[KEY_PRESSURE].native_value is None
     assert up.entity_values[KEY_ACCELERATION_X].native_value is None
     assert up.entity_values[KEY_ACCELERATION_Y].native_value is None
     assert up.entity_values[KEY_ACCELERATION_Z].native_value is None

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,12 +3,10 @@ from sensor_state_data import DeviceClass, DeviceKey
 
 from ruuvitag_ble import RuuvitagBluetoothDeviceData
 
-OUTDOOR_SENSOR_DATA = (
+V5_SENSOR_DATA = (
     b"\x05\x05\xa0`\xa0\xc8\x9a\xfd4\x02\x8c\xff\x00cvriv\xde\xad{?\xef\xaf"
 )
-INDOOR_SENSOR_DATA = (
-    b"\x05\x0e\xa4M~\xc8\x18\xfc\xbc\xfd\xf0\xff\xb4+\xf6\x00\x10<\xd97\x0f\xf7\xaa\x48"
-)
+V3_SENSOR_DATA = b"\x03\xb2\x0c\x1f\xca \x00z\x00&\x03\xd0\x08\x8f"
 
 KEY_TEMPERATURE = DeviceKey(key=DeviceClass.TEMPERATURE, device_id=None)
 KEY_HUMIDITY = DeviceKey(key=DeviceClass.HUMIDITY, device_id=None)
@@ -29,9 +27,9 @@ def bytes_to_service_info(payload: bytes) -> BluetoothServiceInfo:
     )
 
 
-def test_parsing_outdoor():
+def test_parsing_v5():
     device = RuuvitagBluetoothDeviceData()
-    advertisement = bytes_to_service_info(OUTDOOR_SENSOR_DATA)
+    advertisement = bytes_to_service_info(V5_SENSOR_DATA)
     assert device.supported(advertisement)
     up = device.update(advertisement)
     expected_name = "RuuviTag EFAF"
@@ -41,3 +39,16 @@ def test_parsing_outdoor():
     assert up.entity_values[KEY_PRESSURE].native_value == 1013.54  # hPa
     assert up.entity_values[KEY_VOLTAGE].native_value == 2395  # mV
     assert up.entity_values[KEY_MOVEMENT].native_value == 114  # count
+
+
+def test_parsing_v3():
+    device = RuuvitagBluetoothDeviceData()
+    advertisement = bytes_to_service_info(V3_SENSOR_DATA)
+    assert device.supported(advertisement)
+    up = device.update(advertisement)
+    expected_name = "RuuviTag EFAF"
+    assert up.devices[None].name == expected_name  # Parsed from advertisement
+    assert up.entity_values[KEY_TEMPERATURE].native_value == 7.2  # Celsius
+    assert up.entity_values[KEY_HUMIDITY].native_value == 61.84  # %
+    assert up.entity_values[KEY_PRESSURE].native_value == 1013.54  # hPa
+    assert up.entity_values[KEY_VOLTAGE].native_value == 2395  # mV

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -127,7 +127,6 @@ def test_error_v3():
 def test_wrong_mfr():
     device = RuuvitagBluetoothDeviceData()
     advertisement = bytes_to_service_info_wrong_mfr(V3_SENSOR_DATA_ERROR)
-    assert device.supported(advertisement)
     up = device.update(advertisement)
     assert not up.entity_values
 
@@ -135,6 +134,5 @@ def test_wrong_mfr():
 def test_invalid_format():
     device = RuuvitagBluetoothDeviceData()
     advertisement = bytes_to_service_info(INVALID_FORMAT_ERROR)
-    assert device.supported(advertisement)
     up = device.update(advertisement)
     assert not up.entity_values

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -21,6 +21,8 @@ KEY_HUMIDITY = DeviceKey(key=DeviceClass.HUMIDITY, device_id=None)
 KEY_PRESSURE = DeviceKey(key=DeviceClass.PRESSURE, device_id=None)
 KEY_VOLTAGE = DeviceKey(key=DeviceClass.VOLTAGE, device_id=None)
 KEY_MOVEMENT = DeviceKey(key="movement_counter", device_id=None)
+KEY_SIGNAL_STRENGTH = DeviceKey(key=DeviceClass.SIGNAL_STRENGTH, device_id=None)
+KEY_SEQUENCE_NUMBER = DeviceKey(key="sequence_number", device_id=None)
 KEY_ACCELERATION_X = DeviceKey(key="acceleration_x", device_id=None)
 KEY_ACCELERATION_Y = DeviceKey(key="acceleration_y", device_id=None)
 KEY_ACCELERATION_Z = DeviceKey(key="acceleration_z", device_id=None)
@@ -63,10 +65,12 @@ def test_parsing_v5():
     assert up.entity_values[KEY_PRESSURE].native_value == 1013.54  # hPa
     assert up.entity_values[KEY_VOLTAGE].native_value == 2395  # mV
     assert up.entity_values[KEY_MOVEMENT].native_value == 114  # count
-    assert up.entity_values[KEY_ACCELERATION_X].native_value == -7.02  # acceleration
-    assert up.entity_values[KEY_ACCELERATION_Y].native_value == 6.39  # acceleration
-    assert up.entity_values[KEY_ACCELERATION_Z].native_value == -2.51  # acceleration
-    assert up.entity_values[KEY_ACCELERATION_TOTAL].native_value == 9.82  # acceleration
+    assert up.entity_values[KEY_SIGNAL_STRENGTH].native_value == 0  # dBm
+    assert up.entity_values[KEY_SEQUENCE_NUMBER].native_value == 0  # count
+    assert up.entity_values[KEY_ACCELERATION_X].native_value == -7.02  # m/s^2
+    assert up.entity_values[KEY_ACCELERATION_Y].native_value == 6.39  # m/s^2
+    assert up.entity_values[KEY_ACCELERATION_Z].native_value == -2.51  # m/s^2
+    assert up.entity_values[KEY_ACCELERATION_TOTAL].native_value == 9.82  # m/s^2
 
 
 def test_error_v5():
@@ -80,6 +84,7 @@ def test_error_v5():
     assert up.entity_values[KEY_HUMIDITY].native_value is None
     assert up.entity_values[KEY_PRESSURE].native_value is None
     assert up.entity_values[KEY_VOLTAGE].native_value is None
+    assert up.entity_values[KEY_SIGNAL_STRENGTH].native_value is None
     assert up.entity_values[KEY_ACCELERATION_X].native_value is None
     assert up.entity_values[KEY_ACCELERATION_Y].native_value is None
     assert up.entity_values[KEY_ACCELERATION_Z].native_value is None
@@ -100,10 +105,10 @@ def test_parsing_v3():
     assert up.entity_values[KEY_HUMIDITY].native_value == 89.0  # %
     assert up.entity_values[KEY_PRESSURE].native_value == 1017.44  # hPa
     assert up.entity_values[KEY_VOLTAGE].native_value == 2191  # mV
-    assert up.entity_values[KEY_ACCELERATION_X].native_value == 1.2  # acceleration
-    assert up.entity_values[KEY_ACCELERATION_Y].native_value == 0.37  # acceleration
-    assert up.entity_values[KEY_ACCELERATION_Z].native_value == 9.56  # acceleration
-    assert up.entity_values[KEY_ACCELERATION_TOTAL].native_value == 9.65  # acceleration
+    assert up.entity_values[KEY_ACCELERATION_X].native_value == 1.2  # m/s^2
+    assert up.entity_values[KEY_ACCELERATION_Y].native_value == 0.37  # m/s^2
+    assert up.entity_values[KEY_ACCELERATION_Z].native_value == 9.56  # m/s^2
+    assert up.entity_values[KEY_ACCELERATION_TOTAL].native_value == 9.65  # m/s^2
 
 
 def test_error_v3():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -66,7 +66,7 @@ def test_parsing_v5():
     assert up.entity_values[KEY_VOLTAGE].native_value == 2395  # mV
     assert up.entity_values[KEY_MOVEMENT].native_value == 114  # count
     assert up.entity_values[KEY_TX_POWER].native_value == 4  # dBm
-    assert up.entity_values[KEY_SEQUENCE_NUMBER].native_value == 0  # count
+    assert up.entity_values[KEY_SEQUENCE_NUMBER].native_value == 26998  # count
     assert up.entity_values[KEY_ACCELERATION_X].native_value == -7.02  # m/s^2
     assert up.entity_values[KEY_ACCELERATION_Y].native_value == 6.39  # m/s^2
     assert up.entity_values[KEY_ACCELERATION_Z].native_value == -2.51  # m/s^2

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -7,12 +7,19 @@ V5_SENSOR_DATA = (
     b"\x05\x05\xa0`\xa0\xc8\x9a\xfd4\x02\x8c\xff\x00cvriv\xde\xad{?\xef\xaf"
 )
 V3_SENSOR_DATA = b"\x03\xb2\x0c\x1f\xca \x00z\x00&\x03\xd0\x08\x8f"
+V5_SENSOR_DATA_SHORT = (
+    b"\x05\x05\xa0`\xa0\xc8\x9a\xfd4\x02\x8c\xff\x00cvriv\xde\xad{?\xef"
+)
+V3_SENSOR_DATA_SHORT = b"\x03\xb2\x0c\x1f\xca \x00z\x00&\x03\xd0\x08"
+V5_SENSOR_DATA_ERROR = b"\x05\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
+V3_SENSOR_DATA_ERROR = b"\x03\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
 
 KEY_TEMPERATURE = DeviceKey(key=DeviceClass.TEMPERATURE, device_id=None)
 KEY_HUMIDITY = DeviceKey(key=DeviceClass.HUMIDITY, device_id=None)
 KEY_PRESSURE = DeviceKey(key=DeviceClass.PRESSURE, device_id=None)
 KEY_VOLTAGE = DeviceKey(key=DeviceClass.VOLTAGE, device_id=None)
 KEY_MOVEMENT = DeviceKey(key="movement_counter", device_id=None)
+KEY_ACCELERATION = DeviceKey(key=DeviceClass.ACCELERATION, device_id=None)
 
 
 def bytes_to_service_info(payload: bytes) -> BluetoothServiceInfo:
@@ -39,6 +46,22 @@ def test_parsing_v5():
     assert up.entity_values[KEY_PRESSURE].native_value == 1013.54  # hPa
     assert up.entity_values[KEY_VOLTAGE].native_value == 2395  # mV
     assert up.entity_values[KEY_MOVEMENT].native_value == 114  # count
+    assert up.entity_values[KEY_ACCELERATION].native_value == 0  # acceleration
+
+
+def test_error_v5():
+    device = RuuvitagBluetoothDeviceData()
+    advertisement = bytes_to_service_info(V5_SENSOR_DATA_ERROR)
+    assert device.supported(advertisement)
+    up = device.update(advertisement)
+    expected_name = "RuuviTag DCFE"
+    assert up.devices[None].name == expected_name  # Parsed from advertisement
+    assert up.entity_values[KEY_TEMPERATURE].native_value == 7.2  # Celsius
+    assert up.entity_values[KEY_HUMIDITY].native_value == 61.84  # %
+    assert up.entity_values[KEY_PRESSURE].native_value == 1013.54  # hPa
+    assert up.entity_values[KEY_VOLTAGE].native_value == 2395  # mV
+    assert up.entity_values[KEY_MOVEMENT].native_value == 114  # count
+    assert up.entity_values[KEY_ACCELERATION].native_value == 0  # acceleration
 
 
 def test_parsing_v3():
@@ -52,3 +75,4 @@ def test_parsing_v3():
     assert up.entity_values[KEY_HUMIDITY].native_value == 89.0  # %
     assert up.entity_values[KEY_PRESSURE].native_value == 1017.44  # hPa
     assert up.entity_values[KEY_VOLTAGE].native_value == 2191  # mV
+    assert up.entity_values[KEY_ACCELERATION].native_value == 0  # acceleration

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -21,8 +21,8 @@ KEY_HUMIDITY = DeviceKey(key=DeviceClass.HUMIDITY, device_id=None)
 KEY_PRESSURE = DeviceKey(key=DeviceClass.PRESSURE, device_id=None)
 KEY_VOLTAGE = DeviceKey(key=DeviceClass.VOLTAGE, device_id=None)
 KEY_MOVEMENT = DeviceKey(key="movement_counter", device_id=None)
-KEY_SIGNAL_STRENGTH = DeviceKey(key=DeviceClass.SIGNAL_STRENGTH, device_id=None)
-KEY_SEQUENCE_NUMBER = DeviceKey(key="sequence_number", device_id=None)
+KEY_TX_POWER = DeviceKey(key="tx_power", device_id=None)
+KEY_SEQUENCE_NUMBER = DeviceKey(key="measurement_sequence_number", device_id=None)
 KEY_ACCELERATION_X = DeviceKey(key="acceleration_x", device_id=None)
 KEY_ACCELERATION_Y = DeviceKey(key="acceleration_y", device_id=None)
 KEY_ACCELERATION_Z = DeviceKey(key="acceleration_z", device_id=None)
@@ -65,7 +65,7 @@ def test_parsing_v5():
     assert up.entity_values[KEY_PRESSURE].native_value == 1013.54  # hPa
     assert up.entity_values[KEY_VOLTAGE].native_value == 2395  # mV
     assert up.entity_values[KEY_MOVEMENT].native_value == 114  # count
-    assert up.entity_values[KEY_SIGNAL_STRENGTH].native_value == 0  # dBm
+    assert up.entity_values[KEY_TX_POWER].native_value == 4  # dBm
     assert up.entity_values[KEY_SEQUENCE_NUMBER].native_value == 0  # count
     assert up.entity_values[KEY_ACCELERATION_X].native_value == -7.02  # m/s^2
     assert up.entity_values[KEY_ACCELERATION_Y].native_value == 6.39  # m/s^2
@@ -84,7 +84,7 @@ def test_error_v5():
     assert up.entity_values[KEY_HUMIDITY].native_value is None
     assert up.entity_values[KEY_PRESSURE].native_value is None
     assert up.entity_values[KEY_VOLTAGE].native_value is None
-    assert up.entity_values[KEY_SIGNAL_STRENGTH].native_value is None
+    assert up.entity_values[KEY_TX_POWER].native_value is None
     assert up.entity_values[KEY_ACCELERATION_X].native_value is None
     assert up.entity_values[KEY_ACCELERATION_Y].native_value is None
     assert up.entity_values[KEY_ACCELERATION_Z].native_value is None

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,3 +1,4 @@
+import pytest
 from home_assistant_bluetooth import BluetoothServiceInfo
 from sensor_state_data import DeviceClass, DeviceKey
 
@@ -11,7 +12,7 @@ V5_SENSOR_DATA_SHORT = (
     b"\x05\x05\xa0`\xa0\xc8\x9a\xfd4\x02\x8c\xff\x00cvriv\xde\xad{?\xef"
 )
 V3_SENSOR_DATA_SHORT = b"\x03\xb2\x0c\x1f\xca \x00z\x00&\x03\xd0\x08"
-V5_SENSOR_DATA_ERROR = b"\x05\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
+V5_SENSOR_DATA_ERROR = b"\x05\x80\x00\xff\xff\xff\xff\x80\x00\x80\x00\x80\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
 V3_SENSOR_DATA_ERROR = b"\x03\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
 
 KEY_TEMPERATURE = DeviceKey(key=DeviceClass.TEMPERATURE, device_id=None)
@@ -49,10 +50,10 @@ def test_parsing_v5():
     assert up.entity_values[KEY_PRESSURE].native_value == 1013.54  # hPa
     assert up.entity_values[KEY_VOLTAGE].native_value == 2395  # mV
     assert up.entity_values[KEY_MOVEMENT].native_value == 114  # count
-    assert up.entity_values[KEY_ACCELERATION_X].native_value == 0  # acceleration
-    assert up.entity_values[KEY_ACCELERATION_Y].native_value == 0  # acceleration
-    assert up.entity_values[KEY_ACCELERATION_Z].native_value == 0  # acceleration
-    assert up.entity_values[KEY_ACCELERATION_TOTAL].native_value == 0  # acceleration
+    assert up.entity_values[KEY_ACCELERATION_X].native_value == -7.02  # acceleration
+    assert up.entity_values[KEY_ACCELERATION_Y].native_value == 6.39  # acceleration
+    assert up.entity_values[KEY_ACCELERATION_Z].native_value == -2.51  # acceleration
+    assert up.entity_values[KEY_ACCELERATION_TOTAL].native_value == 9.82  # acceleration
 
 
 def test_error_v5():
@@ -62,15 +63,16 @@ def test_error_v5():
     up = device.update(advertisement)
     expected_name = "RuuviTag DCFE"
     assert up.devices[None].name == expected_name  # Parsed from advertisement
-    assert up.entity_values[KEY_TEMPERATURE].native_value == 7.2  # Celsius
-    assert up.entity_values[KEY_HUMIDITY].native_value == 61.84  # %
-    assert up.entity_values[KEY_PRESSURE].native_value == 1013.54  # hPa
-    assert up.entity_values[KEY_VOLTAGE].native_value == 2395  # mV
-    assert up.entity_values[KEY_MOVEMENT].native_value == 114  # count
-    assert up.entity_values[KEY_ACCELERATION_X].native_value == 0  # acceleration
-    assert up.entity_values[KEY_ACCELERATION_Y].native_value == 0  # acceleration
-    assert up.entity_values[KEY_ACCELERATION_Z].native_value == 0  # acceleration
-    assert up.entity_values[KEY_ACCELERATION_TOTAL].native_value == 0  # acceleration
+    assert up.entity_values[KEY_TEMPERATURE].native_value is None
+    assert up.entity_values[KEY_HUMIDITY].native_value is None
+    assert up.entity_values[KEY_PRESSURE].native_value is None
+    assert up.entity_values[KEY_ACCELERATION_X].native_value is None
+    assert up.entity_values[KEY_ACCELERATION_Y].native_value is None
+    assert up.entity_values[KEY_ACCELERATION_Z].native_value is None
+    assert up.entity_values[KEY_ACCELERATION_TOTAL].native_value is None
+    advertisement = bytes_to_service_info(V5_SENSOR_DATA_SHORT)
+    with pytest.raises(ValueError):
+        device.update(advertisement)
 
 
 def test_parsing_v3():
@@ -84,10 +86,10 @@ def test_parsing_v3():
     assert up.entity_values[KEY_HUMIDITY].native_value == 89.0  # %
     assert up.entity_values[KEY_PRESSURE].native_value == 1017.44  # hPa
     assert up.entity_values[KEY_VOLTAGE].native_value == 2191  # mV
-    assert up.entity_values[KEY_ACCELERATION_X].native_value == 0  # acceleration
-    assert up.entity_values[KEY_ACCELERATION_Y].native_value == 0  # acceleration
-    assert up.entity_values[KEY_ACCELERATION_Z].native_value == 0  # acceleration
-    assert up.entity_values[KEY_ACCELERATION_TOTAL].native_value == 0  # acceleration
+    assert up.entity_values[KEY_ACCELERATION_X].native_value == 1.2  # acceleration
+    assert up.entity_values[KEY_ACCELERATION_Y].native_value == 0.37  # acceleration
+    assert up.entity_values[KEY_ACCELERATION_Z].native_value == 9.56  # acceleration
+    assert up.entity_values[KEY_ACCELERATION_TOTAL].native_value == 9.65  # acceleration
 
 
 def test_error_v3():
@@ -97,11 +99,13 @@ def test_error_v3():
     up = device.update(advertisement)
     expected_name = "RuuviTag DCFE"
     assert up.devices[None].name == expected_name  # Parsed from advertisement
-    assert up.entity_values[KEY_TEMPERATURE].native_value == 7.2  # Celsius
-    assert up.entity_values[KEY_HUMIDITY].native_value == 61.84  # %
-    assert up.entity_values[KEY_PRESSURE].native_value == 1013.54  # hPa
-    assert up.entity_values[KEY_VOLTAGE].native_value == 2395  # mV
-    assert up.entity_values[KEY_ACCELERATION_X].native_value == 0  # acceleration
-    assert up.entity_values[KEY_ACCELERATION_Y].native_value == 0  # acceleration
-    assert up.entity_values[KEY_ACCELERATION_Z].native_value == 0  # acceleration
-    assert up.entity_values[KEY_ACCELERATION_TOTAL].native_value == 0  # acceleration
+    assert up.entity_values[KEY_TEMPERATURE].native_value is None
+    assert up.entity_values[KEY_HUMIDITY].native_value is None
+    assert up.entity_values[KEY_PRESSURE].native_value is None
+    assert up.entity_values[KEY_ACCELERATION_X].native_value is None
+    assert up.entity_values[KEY_ACCELERATION_Y].native_value is None
+    assert up.entity_values[KEY_ACCELERATION_Z].native_value is None
+    assert up.entity_values[KEY_ACCELERATION_TOTAL].native_value is None
+    advertisement = bytes_to_service_info(V3_SENSOR_DATA_SHORT)
+    with pytest.raises(ValueError):
+        device.update(advertisement)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -19,7 +19,10 @@ KEY_HUMIDITY = DeviceKey(key=DeviceClass.HUMIDITY, device_id=None)
 KEY_PRESSURE = DeviceKey(key=DeviceClass.PRESSURE, device_id=None)
 KEY_VOLTAGE = DeviceKey(key=DeviceClass.VOLTAGE, device_id=None)
 KEY_MOVEMENT = DeviceKey(key="movement_counter", device_id=None)
-KEY_ACCELERATION = DeviceKey(key=DeviceClass.ACCELERATION, device_id=None)
+KEY_ACCELERATION_X = DeviceKey(key="acceleration_x", device_id=None)
+KEY_ACCELERATION_Y = DeviceKey(key="acceleration_y", device_id=None)
+KEY_ACCELERATION_Z = DeviceKey(key="acceleration_z", device_id=None)
+KEY_ACCELERATION_TOTAL = DeviceKey(key="acceleration_total", device_id=None)
 
 
 def bytes_to_service_info(payload: bytes) -> BluetoothServiceInfo:
@@ -46,7 +49,10 @@ def test_parsing_v5():
     assert up.entity_values[KEY_PRESSURE].native_value == 1013.54  # hPa
     assert up.entity_values[KEY_VOLTAGE].native_value == 2395  # mV
     assert up.entity_values[KEY_MOVEMENT].native_value == 114  # count
-    assert up.entity_values[KEY_ACCELERATION].native_value == 0  # acceleration
+    assert up.entity_values[KEY_ACCELERATION_X].native_value == 0  # acceleration
+    assert up.entity_values[KEY_ACCELERATION_Y].native_value == 0  # acceleration
+    assert up.entity_values[KEY_ACCELERATION_Z].native_value == 0  # acceleration
+    assert up.entity_values[KEY_ACCELERATION_TOTAL].native_value == 0  # acceleration
 
 
 def test_error_v5():
@@ -61,7 +67,10 @@ def test_error_v5():
     assert up.entity_values[KEY_PRESSURE].native_value == 1013.54  # hPa
     assert up.entity_values[KEY_VOLTAGE].native_value == 2395  # mV
     assert up.entity_values[KEY_MOVEMENT].native_value == 114  # count
-    assert up.entity_values[KEY_ACCELERATION].native_value == 0  # acceleration
+    assert up.entity_values[KEY_ACCELERATION_X].native_value == 0  # acceleration
+    assert up.entity_values[KEY_ACCELERATION_Y].native_value == 0  # acceleration
+    assert up.entity_values[KEY_ACCELERATION_Z].native_value == 0  # acceleration
+    assert up.entity_values[KEY_ACCELERATION_TOTAL].native_value == 0  # acceleration
 
 
 def test_parsing_v3():
@@ -75,4 +84,24 @@ def test_parsing_v3():
     assert up.entity_values[KEY_HUMIDITY].native_value == 89.0  # %
     assert up.entity_values[KEY_PRESSURE].native_value == 1017.44  # hPa
     assert up.entity_values[KEY_VOLTAGE].native_value == 2191  # mV
-    assert up.entity_values[KEY_ACCELERATION].native_value == 0  # acceleration
+    assert up.entity_values[KEY_ACCELERATION_X].native_value == 0  # acceleration
+    assert up.entity_values[KEY_ACCELERATION_Y].native_value == 0  # acceleration
+    assert up.entity_values[KEY_ACCELERATION_Z].native_value == 0  # acceleration
+    assert up.entity_values[KEY_ACCELERATION_TOTAL].native_value == 0  # acceleration
+
+
+def test_error_v3():
+    device = RuuvitagBluetoothDeviceData()
+    advertisement = bytes_to_service_info(V5_SENSOR_DATA_ERROR)
+    assert device.supported(advertisement)
+    up = device.update(advertisement)
+    expected_name = "RuuviTag DCFE"
+    assert up.devices[None].name == expected_name  # Parsed from advertisement
+    assert up.entity_values[KEY_TEMPERATURE].native_value == 7.2  # Celsius
+    assert up.entity_values[KEY_HUMIDITY].native_value == 61.84  # %
+    assert up.entity_values[KEY_PRESSURE].native_value == 1013.54  # hPa
+    assert up.entity_values[KEY_VOLTAGE].native_value == 2395  # mV
+    assert up.entity_values[KEY_ACCELERATION_X].native_value == 0  # acceleration
+    assert up.entity_values[KEY_ACCELERATION_Y].native_value == 0  # acceleration
+    assert up.entity_values[KEY_ACCELERATION_Z].native_value == 0  # acceleration
+    assert up.entity_values[KEY_ACCELERATION_TOTAL].native_value == 0  # acceleration

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -18,7 +18,7 @@ KEY_MOVEMENT = DeviceKey(key="movement_counter", device_id=None)
 def bytes_to_service_info(payload: bytes) -> BluetoothServiceInfo:
     return BluetoothServiceInfo(
         name="Test",
-        address="00:00:00:00:00:00",
+        address="AB:CD:EF:BA:DC:FE",
         rssi=-60,
         manufacturer_data={1177: payload},
         service_data={},
@@ -32,7 +32,7 @@ def test_parsing_v5():
     advertisement = bytes_to_service_info(V5_SENSOR_DATA)
     assert device.supported(advertisement)
     up = device.update(advertisement)
-    expected_name = "RuuviTag EFAF"
+    expected_name = "RuuviTag DCFE"
     assert up.devices[None].name == expected_name  # Parsed from advertisement
     assert up.entity_values[KEY_TEMPERATURE].native_value == 7.2  # Celsius
     assert up.entity_values[KEY_HUMIDITY].native_value == 61.84  # %
@@ -46,9 +46,9 @@ def test_parsing_v3():
     advertisement = bytes_to_service_info(V3_SENSOR_DATA)
     assert device.supported(advertisement)
     up = device.update(advertisement)
-    expected_name = "RuuviTag EFAF"
+    expected_name = "RuuviTag DCFE"
     assert up.devices[None].name == expected_name  # Parsed from advertisement
-    assert up.entity_values[KEY_TEMPERATURE].native_value == 7.2  # Celsius
-    assert up.entity_values[KEY_HUMIDITY].native_value == 61.84  # %
-    assert up.entity_values[KEY_PRESSURE].native_value == 1013.54  # hPa
-    assert up.entity_values[KEY_VOLTAGE].native_value == 2395  # mV
+    assert up.entity_values[KEY_TEMPERATURE].native_value == 12.31  # Celsius
+    assert up.entity_values[KEY_HUMIDITY].native_value == 89.0  # %
+    assert up.entity_values[KEY_PRESSURE].native_value == 1017.44  # hPa
+    assert up.entity_values[KEY_VOLTAGE].native_value == 2191  # mV


### PR DESCRIPTION
This PR adds the individual acceleration values.  These are super handy because they help tell you the orientation of the sensor.  E.g. if the sensor is on its side the Z axis will report acceleration close to zero, whereas when the sensor is lying flat it will report acceleration close to 9.8 m/s^2 (generally 1G).  

Also bubbled up now are the tx power and sequence counters on the V5 version of the firmware.

Lastly with this PR comes some unit test improvments and code coverage improvements.