### PR TITLE
Add acceleration values

### DIFF
--- a/src/ruuvitag_ble/df3_decoder.py
+++ b/src/ruuvitag_ble/df3_decoder.py
@@ -48,7 +48,7 @@ class DataFormat3Decoder:
         ax, ay, az = self.acceleration_vector_mg
         if ax is None or ay is None or az is None:
             return None
-        return math.sqrt(ax * ax + ay * ay + az * az)
+        return math.hypot(ax, ay, az)
 
     @property
     def battery_voltage_mv(self) -> int | None:

--- a/src/ruuvitag_ble/df5_decoder.py
+++ b/src/ruuvitag_ble/df5_decoder.py
@@ -2,6 +2,7 @@
 Decoder for RuuviTag Data Format 5 data.
 
 Based on https://github.com/ttu/ruuvitag-sensor/blob/23e6555/ruuvitag_sensor/decoder.py (MIT Licensed)
+Ruuvi Sensor Protocols: https://github.com/ruuvi/ruuvi-sensor-protocols/blob/master/dataformat_05.md
 """
 
 from __future__ import annotations

--- a/src/ruuvitag_ble/df5_decoder.py
+++ b/src/ruuvitag_ble/df5_decoder.py
@@ -50,7 +50,7 @@ class DataFormat5Decoder:
         ax, ay, az = self.acceleration_vector_mg
         if ax is None or ay is None or az is None:
             return None
-        return math.sqrt(ax * ax + ay * ay + az * az)
+        return math.hypot(ax, ay, az)
 
     @property
     def battery_voltage_mv(self) -> int | None:

--- a/src/ruuvitag_ble/parser.py
+++ b/src/ruuvitag_ble/parser.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import math
 
 from bluetooth_data_tools import short_address
 from bluetooth_sensor_state_data import BluetoothData
@@ -80,3 +81,43 @@ class RuuvitagBluetoothDeviceData(BluetoothData):
                 native_unit_of_measurement=None,
                 native_value=decoder.movement_counter,
             )
+
+        try:
+            acc_x_mg, acc_y_mg, acc_z_mg = decoder.acceleration_vector_mg
+            # Typing ignores are used here, as the arising TypeErrors
+            # will be caught at runtime (IOW, we don't waste runtime doing
+            # unlikely type checks).
+            acc_x_mss = round(acc_x_mg * 0.00980665, 2)  # type: ignore
+            acc_y_mss = round(acc_y_mg * 0.00980665, 2)  # type: ignore
+            acc_z_mss = round(acc_z_mg * 0.00980665, 2)  # type: ignore
+            acc_total_mss = round(
+                math.hypot(acc_x_mss, acc_y_mss, acc_z_mss),
+                2,
+            )
+        except TypeError:  # When any of the acceleration values are None (unlikely)
+            acc_total_mss = acc_x_mss = acc_y_mss = acc_z_mss = None  # type: ignore
+
+        self.update_sensor(
+            key="acceleration_x",
+            device_class=DeviceClass.ACCELERATION,
+            native_unit_of_measurement=Units.ACCELERATION_METERS_PER_SQUARE_SECOND,
+            native_value=acc_x_mss,
+        )
+        self.update_sensor(
+            key="acceleration_y",
+            device_class=DeviceClass.ACCELERATION,
+            native_unit_of_measurement=Units.ACCELERATION_METERS_PER_SQUARE_SECOND,
+            native_value=acc_y_mss,
+        )
+        self.update_sensor(
+            key="acceleration_z",
+            device_class=DeviceClass.ACCELERATION,
+            native_unit_of_measurement=Units.ACCELERATION_METERS_PER_SQUARE_SECOND,
+            native_value=acc_z_mss,
+        )
+        self.update_sensor(
+            key="acceleration_total",
+            device_class=DeviceClass.ACCELERATION,
+            native_unit_of_measurement=Units.ACCELERATION_METERS_PER_SQUARE_SECOND,
+            native_value=acc_total_mss,
+        )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -6,6 +6,9 @@ from ruuvitag_ble import RuuvitagBluetoothDeviceData
 V5_OUTDOOR_SENSOR_DATA = (
     b"\x05\x05\xa0`\xa0\xc8\x9a\xfd4\x02\x8c\xff\x00cvriv\xde\xad{?\xef\xaf"
 )
+V5_OUTDOOR_SENSOR_DATA_INVALID_ACCEL = (
+    b"\x05\x05\xa0`\xa0\xc8\x9a\x80\x00\x02\x8c\xff\x00cvriv\xde\xad{?\xef\xaf"
+)
 # Unused
 # INDOOR_SENSOR_DATA = (
 #     b"\x05\x0e\xa4M~\xc8\x18\xfc\xbc\xfd\xf0\xff\xb4+\xf6\x00\x10<\xd97\x0f\xf7\xaa\x48"
@@ -17,6 +20,10 @@ KEY_HUMIDITY = DeviceKey(key=DeviceClass.HUMIDITY, device_id=None)
 KEY_PRESSURE = DeviceKey(key=DeviceClass.PRESSURE, device_id=None)
 KEY_VOLTAGE = DeviceKey(key=DeviceClass.VOLTAGE, device_id=None)
 KEY_MOVEMENT = DeviceKey(key="movement_counter", device_id=None)
+KEY_ACCELERATION_X = DeviceKey(key="acceleration_x", device_id=None)
+KEY_ACCELERATION_Y = DeviceKey(key="acceleration_y", device_id=None)
+KEY_ACCELERATION_Z = DeviceKey(key="acceleration_z", device_id=None)
+KEY_ACCELERATION_TOTAL = DeviceKey(key="acceleration_total", device_id=None)
 
 
 def bytes_to_service_info(payload: bytes) -> BluetoothServiceInfo:
@@ -43,6 +50,10 @@ def test_parsing_v5():
     assert up.entity_values[KEY_PRESSURE].native_value == 1013.54  # hPa
     assert up.entity_values[KEY_VOLTAGE].native_value == 2395  # mV
     assert up.entity_values[KEY_MOVEMENT].native_value == 114  # count
+    assert up.entity_values[KEY_ACCELERATION_X].native_value == -7.02  # m/s^2
+    assert up.entity_values[KEY_ACCELERATION_Y].native_value == 6.39  # m/s^2
+    assert up.entity_values[KEY_ACCELERATION_Z].native_value == -2.51  # m/s^2
+    assert up.entity_values[KEY_ACCELERATION_TOTAL].native_value == 9.82  # m/s^2
 
 
 def test_parsing_v3():
@@ -56,3 +67,21 @@ def test_parsing_v3():
     assert up.entity_values[KEY_HUMIDITY].native_value == 89.0  # %
     assert up.entity_values[KEY_PRESSURE].native_value == 1017.44  # hPa
     assert up.entity_values[KEY_VOLTAGE].native_value == 2191  # mV
+    assert up.entity_values[KEY_ACCELERATION_X].native_value == 1.2  # m/s^2
+    assert up.entity_values[KEY_ACCELERATION_Y].native_value == 0.37  # m/s^2
+    assert up.entity_values[KEY_ACCELERATION_Z].native_value == 9.57  # m/s^2
+    assert up.entity_values[KEY_ACCELERATION_TOTAL].native_value == 9.65  # m/s^2
+
+
+def test_parsing_v5_invalid_acceleration():
+    """
+    Test that invalid acceleration values are handled correctly (any component
+    being invalid invalidates all acceleration values, including the total).
+    """
+    device = RuuvitagBluetoothDeviceData()
+    advertisement = bytes_to_service_info(V5_OUTDOOR_SENSOR_DATA_INVALID_ACCEL)
+    up = device.update(advertisement)
+    assert up.entity_values[KEY_ACCELERATION_X].native_value is None
+    assert up.entity_values[KEY_ACCELERATION_Y].native_value is None
+    assert up.entity_values[KEY_ACCELERATION_Z].native_value is None
+    assert up.entity_values[KEY_ACCELERATION_TOTAL].native_value is None


### PR DESCRIPTION
This is a refresh of #29 that only adds the acceleration values.

Computation of the acceleration total is purposefully duplicated into `parser.py` for performance reasons.